### PR TITLE
fix: CRC bug of SD driver

### DIFF
--- a/components/drivers/sd_card/src/sdcard.c
+++ b/components/drivers/sd_card/src/sdcard.c
@@ -256,7 +256,7 @@ static uint8_t sd_get_csdregister(SD_CSD *SD_csd)
 {
     uint8_t csd_tab[18];
     /*!< Send CMD9 (CSD register) or CMD10(CSD register) */
-    sd_send_cmd(SD_CMD9, 0, 0);
+    sd_send_cmd(SD_CMD9, 0, 1);
     /*!< Wait for response in the R1 format (0x00 is no errors) */
     uint8_t resp = sd_get_response();
     debug_print("[CanMV] %s | resp = %x \r\n", __func__, resp);
@@ -360,7 +360,7 @@ static uint8_t sd_get_cidregister(SD_CID *SD_cid)
 {
     uint8_t cid_tab[18];
     /*!< Send CMD10 (CID register) */
-    sd_send_cmd(SD_CMD10, 0, 0);
+    sd_send_cmd(SD_CMD10, 0, 1);
     /*!< Wait for response in the R1 format (0x00 is no errors) */
     if (sd_get_response() != 0x00)
     {
@@ -501,7 +501,7 @@ uint8_t sd_init(void)
     index = 0xFF;
     while (index--)
     {
-        sd_send_cmd(SD_CMD55, 0, 0);
+        sd_send_cmd(SD_CMD55, 0, 1);
         result = sd_get_response();
         sd_end_cmd();
         if (result != 0x01)
@@ -509,7 +509,7 @@ uint8_t sd_init(void)
             debug_print("SD_CMD55 ack %X\r\n", result);
             return 0xFF;
         }
-        sd_send_cmd(SD_ACMD41, 0x40000000, 0);
+        sd_send_cmd(SD_ACMD41, 0x40000000, 1);
         result = sd_get_response();
         sd_end_cmd();
         if (result == 0x00)
@@ -557,7 +557,7 @@ uint8_t sd_init(void)
     }
     if (1 == sd_version)
     {
-        sd_send_cmd(SD_CMD16, 512, 0);
+        sd_send_cmd(SD_CMD16, 512, 1);
         if (sd_get_response() != 0x00)
         {
             sd_end_cmd();
@@ -588,12 +588,12 @@ uint8_t sd_read_sector(uint8_t *data_buff, uint32_t sector, uint32_t count)
     if (count == 1)
     {
         flag = 0;
-        sd_send_cmd(SD_CMD17, sector, 0);
+        sd_send_cmd(SD_CMD17, sector, 1);
     }
     else
     {
         flag = 1;
-        sd_send_cmd(SD_CMD18, sector, 0);
+        sd_send_cmd(SD_CMD18, sector, 1);
     }
     /*!< Check if the SD acknowledged the read block command: R1 response (0x00: no errors) */
     if (sd_get_response() != 0x00)
@@ -615,7 +615,7 @@ uint8_t sd_read_sector(uint8_t *data_buff, uint32_t sector, uint32_t count)
     sd_end_cmd();
     if (flag)
     {
-        sd_send_cmd(SD_CMD12, 0, 0);
+        sd_send_cmd(SD_CMD12, 0, 1);
         sd_get_response();
         sd_end_cmd();
         sd_end_cmd();
@@ -640,15 +640,15 @@ uint8_t sd_write_sector(uint8_t *data_buff, uint32_t sector, uint32_t count)
     if (count == 1)
     {
         frame[1] = SD_START_DATA_SINGLE_BLOCK_WRITE;
-        sd_send_cmd(SD_CMD24, sector, 0);
+        sd_send_cmd(SD_CMD24, sector, 1);
     }
     else
     {
         frame[1] = SD_START_DATA_MULTIPLE_BLOCK_WRITE;
-        sd_send_cmd(SD_ACMD23, count, 0);
+        sd_send_cmd(SD_ACMD23, count, 1);
         sd_get_response();
         sd_end_cmd();
-        sd_send_cmd(SD_CMD25, sector, 0);
+        sd_send_cmd(SD_CMD25, sector, 1);
     }
     /*!< Check if the SD acknowledged the write block command: R1 response (0x00: no errors) */
     if (sd_get_response() != 0x00)
@@ -687,12 +687,12 @@ uint8_t sd_read_sector_dma(uint8_t *data_buff, uint32_t sector, uint32_t count)
     if (count == 1)
     {
         flag = 0;
-        sd_send_cmd(SD_CMD17, sector, 0);
+        sd_send_cmd(SD_CMD17, sector, 1);
     }
     else
     {
         flag = 1;
-        sd_send_cmd(SD_CMD18, sector, 0);
+        sd_send_cmd(SD_CMD18, sector, 1);
     }
     /*!< Check if the SD acknowledged the read block command: R1 response (0x00: no errors) */
     if (sd_get_response() != 0x00)
@@ -715,7 +715,7 @@ uint8_t sd_read_sector_dma(uint8_t *data_buff, uint32_t sector, uint32_t count)
     sd_end_cmd();
     if (flag)
     {
-        sd_send_cmd(SD_CMD12, 0, 0);
+        sd_send_cmd(SD_CMD12, 0, 1);
         sd_get_response();
         sd_end_cmd();
         sd_end_cmd();
@@ -738,7 +738,7 @@ uint8_t sd_write_sector_dma(uint8_t *data_buff, uint32_t sector, uint32_t count)
             shift = i << 9;
         else
             shift = i;
-        sd_send_cmd(SD_CMD24, sector + shift, 0);
+        sd_send_cmd(SD_CMD24, sector + shift, 1);
         /*!< Check if the SD acknowledged the write block command: R1 response (0x00: no errors) */
         if (sd_get_response() != 0x00)
         {


### PR DESCRIPTION
* the end bit after CRC7 must always '1'